### PR TITLE
Enable Snyk in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@3.4.2
+  snyk: snyk/snyk@0.0.10
 
 executors:
   docker-executor:
@@ -20,6 +21,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
+            - v1-dependencies-{{ checksum "build.gradle" }}-{{ checksum "gradle.properties" }}
             - v1-dependencies-{{ checksum "build.gradle" }}
             - v1-dependencies-
       - run:
@@ -28,7 +30,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle
-          key: v1-dependencies-{{ checksum "build.gradle" }}
+          key: v1-dependencies-{{ checksum "build.gradle" }}-{{ checksum "gradle.properties" }}
       - persist_to_workspace:
           root: "."
           paths:
@@ -75,6 +77,17 @@ jobs:
           name: Test image
           command: scripts/test_container.sh
 
+  snyk:
+    docker:
+      - image: circleci/openjdk:11
+    steps:
+      - attach_workspace:
+          at: "."
+      - snyk/scan:
+          additional-arguments: '--configuration-attributes=buildtype:release,usage:java-runtime'
+          project: '${CIRCLE_PROJECT_REPONAME}'
+          severity-threshold: high
+
   sonarcloud:
     executor: graal-executor
     steps:
@@ -111,6 +124,10 @@ workflows:
   build:
     jobs:
       - build
+      - snyk:
+          context: Snyk
+          requires:
+            - build
       - test:
           requires:
             - build
@@ -124,6 +141,7 @@ workflows:
       - deploy:
           context: Docker
           requires:
+            - snyk
             - sonarcloud
             - test-container
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
       - attach_workspace:
           at: "."
       - snyk/scan:
-          additional-arguments: '--configuration-attributes=buildtype:release,usage:java-runtime'
+          additional-arguments: '--configuration-attributes=usage:java-runtime'
           project: '${CIRCLE_PROJECT_REPONAME}'
           severity-threshold: high
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@ Include a link to the original ticket.
 
 **Deployment**
 
-* [ ] GitLab CI/CD config updated
+* [ ] CI/CD config updated
 * [ ] Docker image builds and boots
 
 **Principles**

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,13 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.14.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JAVA-COMH2DATABASE-31685:
+    - '*':
+        reason: no fix
+        expires: 2020-07-21T00:00:00.000Z
+  SNYK-JAVA-ORGKEYCLOAK-568921:
+    - '*':
+        reason: no fix
+        expires: 2020-07-21T00:00:00.000Z
+patch: {}

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     // Data
     implementation "io.quarkus:quarkus-hibernate-orm-panache"
     implementation "io.quarkus:quarkus-jdbc-postgresql"
-    implementation "org.postgresql:postgresql:42.2.+"
+    implementation "org.postgresql:postgresql:42.2.14"
 
     // Auth
     implementation "io.quarkus:quarkus-keycloak-authorization"

--- a/build.gradle
+++ b/build.gradle
@@ -15,11 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}") {
-        exclude group: "org.jetbrains.kotlin"
-        exclude group: "com.fasterxml.jackson.module"
-        exclude group: "com.fasterxml.jackson.datatype"
-    }
+    implementation platform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 
     // Kotlin
     implementation "io.quarkus:quarkus-kotlin"
@@ -49,6 +45,7 @@ dependencies {
     // Data
     implementation "io.quarkus:quarkus-hibernate-orm-panache"
     implementation "io.quarkus:quarkus-jdbc-postgresql"
+    implementation "org.postgresql:postgresql:42.2.+"
 
     // Auth
     implementation "io.quarkus:quarkus-keycloak-authorization"
@@ -61,6 +58,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit5:${kotlinVersion}"
     testImplementation "io.quarkus:quarkus-junit5"
     testImplementation "io.quarkus:quarkus-test-h2"
+    testImplementation "com.h2database:h2:1.4.200"
     testImplementation "io.rest-assured:rest-assured"
     testImplementation "io.kotest:kotest-runner-junit5-jvm:${kotestVersion}"
     testImplementation "io.kotest:kotest-assertions-core-jvm:${kotestVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
-quarkusPluginVersion=1.5.1.Final
+quarkusPluginVersion=1.5.2.Final
 quarkusPlatformArtifactId=quarkus-universe-bom
-quarkusPlatformVersion=1.5.1.Final
+quarkusPlatformVersion=1.5.2.Final
 quarkusPlatformGroupId=io.quarkus
 
 kotlinVersion=1.3.72

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@ quarkusPlatformVersion=1.5.2.Final
 quarkusPlatformGroupId=io.quarkus
 
 kotlinVersion=1.3.72
-jacksonVersion=2.10.4
+jacksonVersion=2.11.0
 valiktorVersion=0.11.0
-kotestVersion=4.0.5
+kotestVersion=4.0.7
 mockitoVersion=2.2.0
 
-sonarqubeVersion=2.8
+sonarqubeVersion=3.0
 sonarqubeOrganization=backstage-technical-services
 sonarqubeProjectKey=backstage-technical-services_quarkus-api
 sonarqubeProjectName=Quarkus API

--- a/src/test/kotlin/org/backstage/auth/PolicyTests.kt
+++ b/src/test/kotlin/org/backstage/auth/PolicyTests.kt
@@ -8,12 +8,11 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldStartWith
 import io.quarkus.hibernate.orm.panache.PanacheEntity
-import io.quarkus.launcher.shaded.org.apache.http.auth.BasicUserPrincipal
 import io.quarkus.oidc.runtime.OidcJwtCallerPrincipal
 import io.quarkus.security.UnauthorizedException
 import io.quarkus.security.identity.SecurityIdentity
+import io.quarkus.security.runtime.QuarkusPrincipal
 import io.quarkus.test.junit.QuarkusTest
 import org.junit.jupiter.api.Test
 import java.util.*
@@ -137,7 +136,7 @@ class UserIdTests : FunSpec() {
 
         context("a basic user principle") {
             val user = mock<SecurityIdentity> {
-                on { principal } doReturn BasicUserPrincipal("USERNAME")
+                on { principal } doReturn QuarkusPrincipal("USERNAME")
             }
 
             test("getting the user ID should return null") {


### PR DESCRIPTION
As Snyk's auto-scanning doesn't pick up the dependency versions correctly, this enables Snyk manually in CI using the orb.